### PR TITLE
Added option to show top N (most time consuming) tests

### DIFF
--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -1,4 +1,5 @@
 import operator
+import os
 from time import time
 
 from nose.plugins.base import Plugin
@@ -26,8 +27,9 @@ class TimerPlugin(Plugin):
         """Configures the test timer plugin."""
         super(TimerPlugin, self).configure(options, config)
         self.config = config
+        self.timer_top_n = int(options.timer_top_n)
         self._timed_tests = {}
-
+        
     def startTest(self, test):
         """Initializes a timer before starting a test."""
         self._timer = time()
@@ -36,9 +38,14 @@ class TimerPlugin(Plugin):
         """Report the test times"""
         if not self.enabled:
             return
-        d = sorted(self._timed_tests.iteritems(), key=operator.itemgetter(1))
-        for test, time_taken in d:
-            stream.writeln("%s: %0.4fs" % (test, time_taken))
+
+        d = sorted(self._timed_tests.iteritems(),
+                   key=operator.itemgetter(1),
+                   reverse=True)
+        
+        for i, (test, time_taken) in enumerate(d):
+            if i < self.timer_top_n or self.timer_top_n == -1:
+                stream.writeln("%s: %0.4fs" % (test, time_taken))
 
     def _register_time(self, test):
         self._timed_tests[test.id()] = self._timeTaken()
@@ -51,4 +58,13 @@ class TimerPlugin(Plugin):
 
     def addSuccess(self, test, capt=None):
         self._register_time(test)
+        
+    def addOptions(self, parser, env=os.environ):
+        super(TimerPlugin, self).addOptions(parser, env)
 
+        _help = ("When the timer plugin is enabled, only show the N tests"
+                 " that consume more time. The default, -1, shows all tests.")
+                 
+        parser.add_option("--timer-top-n", action="store", default="-1",
+                          dest="timer_top_n", help=_help)
+                          


### PR DESCRIPTION
## Show only 3

pablo@eulogia:~/workspace/threading2$ nosetests --config=nose.cfg -a smoke core/data/parsers/ --timer-top-n=3
........................................................
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_case_sensitivity: 0.0084s
core.data.parsers.HTTPRequestParser.check_uri_syntax: 0.0040s
core.data.parsers.url.URL.normalize_url: 0.0030s

Ran 56 tests in 0.079s
## Show all

pablo@eulogia:~/workspace/threading2$ nosetests --config=nose.cfg -a smoke core/data/parsers/ 
........................................................
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_case_sensitivity: 0.0084s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_inputs_in_out_form: 0.0041s
core.data.parsers.HTTPRequestParser.check_uri_syntax: 0.0040s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_forms: 0.0037s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_form_without_meth: 0.0034s
core.data.parsers.url.URL.normalize_url: 0.0029s
core.data.parsers.url.URL.**iter**: 0.0028s
core.data.parsers.url.URL.url_join: 0.0022s
core.data.parsers.url.parse_qs: 0.0021s
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_parsed_references: 0.0018s
core.data.parsers.url.URL.is_valid_domain: 0.0016s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_selects_in_out_form: 0.0012s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_form_without_action: 0.0012s
core.data.parsers.url.URL.get_domain_path: 0.0012s
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_regex_urls: 0.0011s
core.data.parsers.url.URL.get_root_domain: 0.0011s
core.data.parsers.url.URL.remove_params: 0.0011s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_textareas_in_out_form: 0.0011s
core.data.parsers.url.URL.get_querystring: 0.0009s
core.data.parsers.url.URL.querystring: 0.0009s
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_baseurl: 0.0009s
core.data.parsers.url.URL.get_port: 0.0009s
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_meta_tags: 0.0009s
core.data.parsers.url.URL.**contains**: 0.0009s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_form_with_invalid_url_in_action: 0.0009s
core.data.parsers.url.URL.get_params: 0.0009s
core.data.parsers.url.URL.**str**: 0.0008s
core.data.parsers.url.URL.from_URL: 0.0008s
core.data.parsers.url.URL.get_params_string: 0.0008s
core.data.parsers.url.URL.has_params: 0.0008s
core.data.parsers.url.URL.**add**: 0.0007s
core.data.parsers.url.URL.**hash**: 0.0007s
core.data.parsers.url.URL.get_path: 0.0007s
core.data.parsers.url.URL.**radd**: 0.0007s
core.data.parsers.url.URL.url_string: 0.0007s
core.data.parsers.url.URL.base_url: 0.0007s
core.data.parsers.url.URL.get_path_qs: 0.0006s
core.data.parsers.url.URL.remove_fragment: 0.0006s
core.data.parsers.HTTPRequestParser.check_version_syntax: 0.0006s
core.data.parsers.url.URL.has_query_string: 0.0006s
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_reference_with_colon: 0.0006s
core.data.parsers.url.URL.get_domain: 0.0006s
core.data.parsers.url.URL.get_protocol: 0.0005s
core.data.parsers.url.URL.get_extension: 0.0005s
core.data.parsers.url.URL.from_parts: 0.0005s
core.data.parsers.url.URL.get_net_location: 0.0005s
core.data.parsers.url.URL.get_path_without_file: 0.0005s
core.data.parsers.tests.test_sgmlparsers.TestHTMLParser.test_no_forms: 0.0005s
core.data.parsers.url.URL.get_file_name: 0.0005s
core.data.parsers.url.URL.uri2url: 0.0005s
core.data.parsers.url.URL.all_but_scheme: 0.0004s
core.data.parsers.url.URL.**unicode**: 0.0004s
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_find_emails: 0.0004s
core.data.parsers.url.URL.**nonzero**: 0.0004s
core.data.parsers.baseparser.BaseParser._decode_url: 0.0003s
core.data.parsers.tests.test_sgmlparsers.TestSGMLParser.test_parser_attrs: 0.0002s

Ran 56 tests in 0.087s

OK
