### PR TITLE
Nosetests verbosity added in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ deps =
     nose-parameterized
     mock
 commands =
-    nosetests
+    nosetests --verbosity 2


### PR DESCRIPTION
It is better to see how tests passed with nosetests verbosity=2.
