### PR TITLE
typos / grammar in readme and project description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 nose-timer
 ==========
 
-A timer plugin for nosetests that answers the question: *how much time does every test takes?*
+A timer plugin for nosetests that answers the question: *how much time does every test take?*
 
 .. image:: https://travis-ci.org/mahmoudimus/nose-timer.png?branch=master
    :target: https://travis-ci.org/mahmoudimus/nose-timer
@@ -44,8 +44,8 @@ How do I color the output and have pretty colors?
 You can highlight slower tests using ``--timer-ok`` and ``--timer-warning`` flags.
 Default time unit is the second, but you can specify it explicitly, e.g. 1s, 100ms.
 
-- Tests which takes less time than ``--timer-ok`` will be highlighted green.
-- Tests which takes less time than ``--timer-warning`` will be highlighted yellow.
+- Tests which take less time than ``--timer-ok`` will be highlighted in green.
+- Tests which take less time than ``--timer-warning`` will be highlighted in yellow.
 - All other tests will be highlighted red.
 
 


### PR DESCRIPTION
if you use "does" it takes away the singular "s"...
"how much time does each test take<del>s</del>"
