### PR TITLE
Implemented timings show up on the same line (#19)

### DIFF
--- a/nosetimer/runner.py
+++ b/nosetimer/runner.py
@@ -1,0 +1,38 @@
+from nose import core
+from nosetimer import utils
+
+
+class TimerTestResult(core.TextTestResult):
+    """Timer test result."""
+
+    def __init__(self, timed_tests, **kwargs):
+        super(TimerTestResult, self).__init__(**kwargs)
+        self._timed_tests = timed_tests
+
+    def addSuccess(self, test):
+        """Called when a test passes."""
+        if self.showAll:
+            result = 'ok'
+            time_taken = self._timed_tests.get(test.id())
+            if time_taken is not None:
+                result += ' ({0})'.format(
+                    utils.colored_time(time_taken, self.config.options))
+            self.stream.writeln(result)
+        elif self.dots:
+            self.stream.write('.')
+            self.stream.flush()
+
+
+class TimerTestRunner(core.TextTestRunner):
+    """Timer test runner."""
+
+    def __init__(self, timed_tests, **kwargs):
+        super(TimerTestRunner, self).__init__(**kwargs)
+        self._timed_tests = timed_tests
+
+    def _makeResult(self):
+        return TimerTestResult(timed_tests=self._timed_tests,
+                               stream=self.stream,
+                               descriptions=self.descriptions,
+                               verbosity=self.verbosity,
+                               config=self.config)

--- a/nosetimer/utils.py
+++ b/nosetimer/utils.py
@@ -1,0 +1,13 @@
+import termcolor
+
+
+def colored_time(time_taken, options):
+    """Get colored string for a given time taken."""
+    time_taken_ms = time_taken * 1000
+    if time_taken_ms <= options.timer_ok:
+        color = 'green'
+    elif time_taken_ms <= options.timer_warning:
+        color = 'yellow'
+    else:
+        color = 'red'
+    return termcolor.colored("{0:0.4f}s".format(time_taken_ms), color)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,6 +2,7 @@ import mock
 import unittest
 
 import nosetimer
+
 from nose_parameterized import parameterized
 
 
@@ -17,11 +18,10 @@ class TestTimerPlugin(unittest.TestCase):
     def test_options(self):
         parser = mock.MagicMock()
         self.plugin.options(parser)
-        self.assertEquals(parser.add_option.call_count, 5)
+        self.assertEquals(parser.add_option.call_count, 4)
 
     def test_configure(self):
-        attributes = ('config', 'timer_top_n', 'timer_ok',
-                      'timer_warning', '_timed_tests')
+        attributes = ('config', 'timer_top_n', '_timed_tests')
         for attr in attributes:
             self.assertFalse(hasattr(self.plugin, attr))
 
@@ -54,15 +54,9 @@ class TestTimerPlugin(unittest.TestCase):
     ])
     def test_parse_time_called(self, option):
         time = '100ms'
-        with mock.patch.object(self.plugin, '_parse_time') as parse:
-            parse.return_value = time
+        with mock.patch.object(self.plugin, '_parse_time') as parse_time:
+            parse_time.return_value = time
             mock_opts = mock.MagicMock(**{option: time})
             self.plugin.configure(mock_opts, None)
-            self.assertEqual(getattr(self.plugin, option), time)
-            parse.assert_any_call(time)
-
-    def test_afterTest(self):
-        self.opts_mock.timer_verbose.return_value = True
-        self.plugin.configure(self.opts_mock, None)
-        # make sure there is no exception if test time result was not found
-        self.plugin.afterTest(self.test_mock)
+            self.assertEqual(getattr(mock_opts, option), time)
+            parse_time.has_call(time)


### PR DESCRIPTION
- Added the `TimerTestResult` and `TimerTestRunner` classes
  to take care of printing time result;
- Added the `colored_time` function that returns time string
  colored depending on passed options;
- Removed the `timer-verbose` option since it is not needed any
  more;
- Corrected unit tests.
