### PR TITLE
Fix timings units

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ tests and the time spent by each one (in seconds):
 How do I show only the ``n`` slowest tests?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For example, to show only the **10** slowest tests, run nosetests with
+For example, to show only the **10** slowest tests, run nosetests with the
 ``--timer-top-n`` flag.
 
 .. code:: bash
@@ -46,19 +46,7 @@ Default time unit is the second, but you can specify it explicitly, e.g. 1s, 100
 
 - Tests which take less time than ``--timer-ok`` will be highlighted in green.
 - Tests which take less time than ``--timer-warning`` will be highlighted in yellow.
-- All other tests will be highlighted red.
-
-
-How do I increase timer verbosity?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default nose-timer outputs test times at the end of all tests.
-You can output test times after each test with ``--timer-verbose`` flag.
-Note that ``--vv`` should be enabled as well to view info logs.
-
-.. code:: bash
-
-    nosetests --with-timer --timer-verbose -vv .
+- All other tests will be highlighted in red.
 
 
 License

--- a/nosetimer/__init__.py
+++ b/nosetimer/__init__.py
@@ -1,1 +1,0 @@
-from nosetimer.plugin import TimerPlugin    # noqa

--- a/nosetimer/utils.py
+++ b/nosetimer/utils.py
@@ -10,4 +10,4 @@ def colored_time(time_taken, options):
         color = 'yellow'
     else:
         color = 'red'
-    return termcolor.colored("{0:0.4f}s".format(time_taken_ms), color)
+    return termcolor.colored("{0:0.4f}s".format(time_taken), color)

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ setup(
     packages=['nosetimer', ],
     install_requires=['termcolor', ],
     license='LICENSE',
-    entry_points='''
-        [nose.plugins.0.10]
-        nosetimer = nosetimer:TimerPlugin
-    ''',
+    entry_points={
+        'nose.plugins.0.10': [
+            'nosetimer = nosetimer.plugin:TimerPlugin',
+        ]
+    },
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,8 +1,7 @@
 import mock
 import unittest
 
-import nosetimer
-
+from nosetimer import plugin
 from nose_parameterized import parameterized
 
 
@@ -10,7 +9,7 @@ class TestTimerPlugin(unittest.TestCase):
 
     def setUp(self):
         super(TestTimerPlugin, self).setUp()
-        self.plugin = nosetimer.TimerPlugin()
+        self.plugin = plugin.TimerPlugin()
         self.test_mock = mock.MagicMock(name='test')
         self.test_mock.id.return_value = 1
         self.opts_mock = mock.MagicMock(name='opts')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import mock
+import unittest
+
+from nosetimer import utils
+from nose_parameterized import parameterized
+
+
+class TestUtils(unittest.TestCase):
+
+    @parameterized.expand([
+        (0.0001, '0.0001s', 'green'),
+        (1,      '1.0000s', 'green'),
+        (1.0001, '1.0001s', 'yellow'),
+        (2.00,   '2.0000s', 'yellow'),
+        (2.0001, '2.0001s', 'red'),
+    ])
+    @mock.patch("nosetimer.utils.termcolor.colored")
+    def test_colored_time(self, time_taken, expected, color, colored_mock):
+        opts_mock = mock.MagicMock(**{
+            'timer_ok': 1000,
+            'timer_warning': 2000
+        })
+        utils.colored_time(time_taken, opts_mock)
+        colored_mock.assert_called_once_with(expected, color)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     termcolor
     mock
 commands =
-    nosetests --verbosity 2
+    nosetests {posargs} --verbosity 2 tests
 
 [testenv:pep8]
 deps =


### PR DESCRIPTION
- Fixed timings that should be shown in seconds instead of milliseconds (committed by the previous commit by mistake);
- Covered with units tests;
- Documentation updated.
