### PR TITLE
Enable python3.4 tests for tox and TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py33
+  - TOXENV=py34
 install:
   - pip install tox
   - pip install mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py33,py27,py26
+envlist = pep8,py33,py34,py27,py26
 
 [testenv]
 deps =


### PR DESCRIPTION
Tests on Python 3.4 passed so I don't see any reason to not include it to our tests suits.

P.S. Sorry for my inactivity in a project.
