### PR TITLE
Add instructions how install the dev version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,14 @@ Or to install the latest development version from Git:
 
     pip install git+git://github.com/mahmoudimus/nose-timer.git
 
+Or to install the latest from source:
+
+.. code::
+
+    git clone https://github.com/mahmoudimus/nose-timer.git
+    cd nose-timer
+    python setup.py install
+
 
 Usage
 -----


### PR DESCRIPTION
Especially important right now because the PyPI version doesn't contain the pretty colours.

See also https://github.com/mahmoudimus/nose-timer/issues/46
