### PR TITLE
Fix name of LICENSE file in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.rst
-include LICENSE.txt
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'nose',
         'termcolor',
     ],
-    license='LICENSE',
+    license='MIT or BSD',
     entry_points={
         'nose.plugins.0.10': [
             'nosetimer = nosetimer.plugin:TimerPlugin',


### PR DESCRIPTION
This avoids a warning during build (and during pip install).

Also, fix license paramater in setup.py. This param should
be the name of the license, not the file containing the
license.  Since this package is dual licensed I copied the
syntax used in setuptools itself which is "XXX or YYY".
