### PR TITLE
Fix Windows, python 2.7 support

### DIFF
--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -1,5 +1,4 @@
 import logging
-import multiprocessing
 import operator
 import os
 import re
@@ -21,7 +20,7 @@ class TimerPlugin(Plugin):
 
     def __init__(self):
         super(TimerPlugin, self).__init__()
-        self._timed_tests = multiprocessing.Manager().dict()
+        self._timed_tests = {}
 
     def _time_taken(self):
         if hasattr(self, '_timer'):


### PR DESCRIPTION
On Windows, the current implementation is non-functional with Python 2.7 as the use of the `multiprocessing` module causes an assertion to fail.

This is all the more a problem because this makes nosetests unusable even when not explicitely specifying the `--with-timer` option (nosetests basically fails when loading the plugin). Put otherwise, installing `nose-timer` prevents the use of `nosetests` altogether in those environments.

This PR is a trivial attempt at fixing this by removing all references to `multiprocessing`. I'm not too familiar with this module but it seems its only reference was to create a dictionary of some sort.

I replaced it with a regular dict and could ran `nose-timer` without any problem.