### PR TITLE
Disabled color support for Windows

### DIFF
--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -60,7 +60,12 @@ class TimerPlugin(Plugin):
             self.timer_top_n = int(options.timer_top_n)
             self.timer_ok = self._parse_time(options.timer_ok)
             self.timer_warning = self._parse_time(options.timer_warning)
-            self.timer_no_color = options.timer_no_color
+
+            # Windows + nosetests does not support colors (even with colorama).
+            if os.name == 'nt':
+                self.timer_no_color = True
+            else:
+                self.timer_no_color = options.timer_no_color
 
     def startTest(self, test):
         """Initializes a timer before starting a test."""
@@ -160,6 +165,8 @@ class TimerPlugin(Plugin):
 
         _no_color_help = "Don't colorize output (useful for non-tty output)."
 
-        parser.add_option("--timer-no-color", action="store_true",
-                          default=False, dest="timer_no_color",
-                          help=_no_color_help)
+        # Windows + nosetests does not support colors (even with colorama).
+        if os.name != 'nt':
+            parser.add_option("--timer-no-color", action="store_true",
+                              default=False, dest="timer_no_color",
+                              help=_no_color_help)


### PR DESCRIPTION
Windows + nosetests sadly doesn't support color output in the terminal.

This PR changes the default on Windows to disable color output (which otherwise makes the output unreadable).