### PR TITLE
Made termcolor not required dependency, but optional.

### DIFF
--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -2,7 +2,6 @@ import logging
 import operator
 import os
 import re
-import termcolor
 import timeit
 
 from nose.plugins import Plugin
@@ -18,6 +17,14 @@ if os.name != 'nt':
     _results_queue = multiprocessing.Queue()
 
 log = logging.getLogger('nose.plugin.timer')
+
+
+def colorize(string, color):
+    try:
+        import termcolor
+        return termcolor.colored(string, color)
+    except ImportError:
+        return string
 
 
 class TimerPlugin(Plugin):
@@ -137,7 +144,7 @@ class TimerPlugin(Plugin):
         """Get formatted and colored string for a given time taken."""
         if self.timer_no_color:
             return "{0:0.4f}s".format(time_taken)
-        return termcolor.colored("{0:0.4f}s".format(time_taken), color)
+        return colorize("{0:0.4f}s".format(time_taken), color)
 
     def _format_report_line(self, test, time_taken, color):
         """Format a single report line."""

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setup(
     url='https://github.com/mahmoudimus/nose-timer',
     packages=['nosetimer', ],
     install_requires=[
-        'nose',
-        'termcolor',
+        'nose'
     ],
     license='MIT or BSD',
     entry_points={

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -71,12 +71,12 @@ class TestTimerPlugin(unittest.TestCase):
         (2.00,   '2.0000s', 'yellow'),
         (2.0001, '2.0001s', 'red'),
     ])
-    @mock.patch("nosetimer.plugin.termcolor.colored")
+    @mock.patch("nosetimer.plugin.colorize")
     def test_colored_time(self, time_taken, expected, color, colored_mock):
         self.plugin._colored_time(time_taken, color)
         colored_mock.assert_called_once_with(expected, color)
 
-    @mock.patch("nosetimer.plugin.termcolor.colored")
+    @mock.patch("nosetimer.plugin.colorize")
     def test_no_color_option(self, colored_mock):
         self.plugin.timer_no_color = True
         self.assertEqual(self.plugin._colored_time(1), "1.0000s")


### PR DESCRIPTION
I'm not certain of the process for submitting pull requests, but I thought I would just present one that might make nose-time a bit more usable for those who might be having trouble installing `termcolor` or has no reason to install it in automated test systems. 

The change makes it such as termcolor is only used for colorizing the output only when it is installed. If it is not installed, then just plain text is used.