### PR TITLE
Allow to export the timings as JSON.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,13 @@ Or to install the latest from source::
 
     git clone https://github.com/mahmoudimus/nose-timer.git
     cd nose-timer
-    python setup.py install
+    pip install .
+
+You can also make a developer install if you plan on modifying the
+source frequently::
+
+    pip install -e .
+
 
 
 Usage
@@ -76,6 +82,29 @@ It is possible to filter results by color. To do so, you can use the
 Or to apply several filters at once::
 
     nosetests --with-timer --timer-filter warning,error
+
+How do I export the results ?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the ``--timer-json-file <myfile.json>`` flag, it will save the result
+in the following format::
+
+  {
+   'tests':
+    {
+    '<test key 1>':
+      {
+        'status': 'success'|'error'|'fail,
+        'time': <float in s>
+      },
+    '<test key 2>':
+      {
+        'status': 'success'|'error'|'fail,
+        'time': <float in s>
+      },
+     ....
+   }
+
 
 
 License

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -21,7 +21,7 @@ class TestTimerPlugin(unittest.TestCase):
     def test_options(self):
         parser = mock.MagicMock()
         self.plugin.options(parser)
-        self.assertEquals(parser.add_option.call_count, 6)
+        self.assertEquals(parser.add_option.call_count, 7)
 
     def test_configure(self):
         attributes = ('config', 'timer_top_n')


### PR DESCRIPTION
Also include the status of tests in dumps cause a faster commit that
fails, or a slower commit that used to be skipped can always happen.

--- 

Typically I want to build a stream graph of time taken by tests across a repository.