### PR TITLE
Report percentage time in printed report

### DIFF
--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -154,13 +154,19 @@ class TimerPlugin(Plugin):
             with open(self.json_file, 'w') as f:
                 json.dump({'tests': dict((k, v) for k, v in d)}, f)
 
+        total_time = sum([vv['time'] for kk, vv in d])
+
         for i, (test, time_and_status) in enumerate(d):
             time_taken = time_and_status['time']
             status = time_and_status['status']
             if i < self.timer_top_n or self.timer_top_n == -1:
                 color = self._get_result_color(time_taken)
-                line = self._format_report_line(test, time_taken,
-                                                color, status)
+                percent = time_taken/total_time*100
+                line = self._format_report_line(test,
+                                                time_taken,
+                                                color,
+                                                status,
+                                                percent)
                 _filter = self._color_to_filter(color)
                 if (self.timer_filter is None or _filter is None or
                         _filter in self.timer_filter):
@@ -192,10 +198,12 @@ class TimerPlugin(Plugin):
             return "{0:0.4f}s".format(time_taken)
         return termcolor.colored("{0:0.4f}s".format(time_taken), color)
 
-    def _format_report_line(self, test, time_taken, color, status):
+    def _format_report_line(self, test, time_taken, color, status, percent):
         """Format a single report line."""
-        return "[{0}]{1}: {2}".format(status, test,
-                                      self._colored_time(time_taken, color))
+        return "[{0}] {3:04.2f}% {1}: {2}".format(
+                                      status, test,
+                                      self._colored_time(time_taken, color),
+                                      percent)
 
     def _register_time(self, test, status=None):
         if self.multiprocessing_enabled:


### PR DESCRIPTION
Looks like that, I think it is useful to get an idea of the time taken by a test, instead of glancing at the total time.
```
[success] 9.22% ipykernel.tests.test_kernel.test_subprocess_print: 3.0287s
[success] 8.99% ipykernel.tests.test_embed_kernel.test_embed_kernel_reentrant: 2.9547s
[success] 6.24% ipykernel.tests.test_embed_kernel.test_embed_kernel_basic: 2.0496s
[success] 6.17% ipykernel.tests.test_kernel.test_subprocess_error: 2.0285s
[success] 6.17% ipykernel.tests.test_kernel.test_sys_path_profile_dir: 2.0278s
[success] 6.15% ipykernel.tests.test_kernel.test_shutdown: 2.0204s
[success] 5.91% ipykernel.tests.test_embed_kernel.test_embed_kernel_namespace: 1.9406s
[success] 5.91% ipykernel.tests.test_start_kernel.test_ipython_start_kernel_userns: 1.9406s
[success] 5.88% ipykernel.tests.test_start_kernel.test_ipython_start_kernel_no_userns: 1.9328s
[success] 4.61% ipykernel.tests.test_message_spec.test_execute_stop_on_error: 1.5151s
[success] 4.16% ipykernel.tests.test_kernel.test_simple_print: 1.3669s
[success] 2.86% ipykernel.tests.test_kernel.test_help_output: 0.9386s
[success] 2.12% ipykernel.tests.test_kernel.test_subprocess_noprint: 0.6979s
```