### PR TITLE
When using '--timer-top-n' output the '--timer-json-file' result in order

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,3 +143,4 @@ Contributors
 - `@hugovk <https://github.com/hugovk>`_
 - `@cgoldberg <https://github.com/cgoldberg>`_
 - `@ereOn <https://github.com/ereOn>`_
+- `@HaraldNordgren <https://github.com/HaraldNordgren>`_

--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -6,11 +7,16 @@ import timeit
 
 from nose.plugins import Plugin
 
-# try to import Queue
 try:
     import Queue
 except ImportError:
     import queue as Queue
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
 
 # define constants
 IS_NT = os.name == 'nt'
@@ -149,10 +155,11 @@ class TimerPlugin(Plugin):
         d = sorted(self._timed_tests.items(),
                    key=lambda item: item[1]['time'],
                    reverse=True)
+
         if self.json_file:
-            import json
+            dict_type = OrderedDict if self.timer_top_n else dict
             with open(self.json_file, 'w') as f:
-                json.dump({'tests': dict((k, v) for k, v in d)}, f)
+                json.dump({'tests': dict_type((k, v) for k, v in d)}, f)
 
         for i, (test, time_and_status) in enumerate(d):
             time_taken = time_and_status['time']

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,14 @@ setup(
         'Stanislav Kudriashev',
         'Raoul Snyman',
         'Corey Goldberg',
+        'Harald Nordgren',
     ]),
     url='https://github.com/mahmoudimus/nose-timer',
     packages=['nosetimer', ],
     install_requires=[
         'nose',
         'termcolor',
+        'ordereddict',
     ],
     license='MIT or BSD',
     entry_points={


### PR DESCRIPTION
'--timer-top-n' gives the slowest tests in order. When used together with '--timer-json-file' I want the json file to have the same ordering.