### PR TITLE
License as MIT (drop BSD 4-Clause license)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,27 +13,3 @@ the following conditions:
 
 The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
-
-BSD License
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software
-   must display the following acknowledgement:
-   This product includes software developed by Balanced Inc.
-4. Neither the name of Balanced Inc. nor the
-   names of its contributors may be used to endorse or promote products
-   derived from this software without specific prior written permission.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ in the following format::
 License
 -------
 
-``nose-timer`` is an MIT/BSD dual-Licensed library.
+``nose-timer`` is MIT Licensed library.
 
 
 Contribute

--- a/README.rst
+++ b/README.rst
@@ -144,3 +144,4 @@ Contributors
 - `@cgoldberg <https://github.com/cgoldberg>`_
 - `@ereOn <https://github.com/ereOn>`_
 - `@HaraldNordgren <https://github.com/HaraldNordgren>`_
+- `@jakirkham <https://github.com/jakirkham>`_

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'termcolor',
         'ordereddict',
     ],
-    license='MIT or BSD',
+    license='MIT',
     entry_points={
         'nose.plugins.0.10': [
             'nosetimer = nosetimer.plugin:TimerPlugin',
@@ -38,7 +38,6 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',


### PR DESCRIPTION
Fixes https://github.com/mahmoudimus/nose-timer/issues/72

Drops the BSD 4-Clause license as discussed in issue ( https://github.com/mahmoudimus/nose-timer/issues/72 ). The consensus was just using the MIT license would be fine. So this switches everything to MIT only.

cc @mahmoudimus @skudriashev @MrOerni @e0ne