### PR TITLE
Drop ordereddict requirement

### DIFF
--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -12,10 +12,7 @@ try:
 except ImportError:
     import queue as Queue
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
 
 # define constants

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     install_requires=[
         'nose',
         'termcolor',
-        'ordereddict',
     ],
     license='MIT',
     entry_points={


### PR DESCRIPTION
As Python 2.7 is the minimum Python supported, every version of Python should have `ordereddict` preincluded in the standard library one way or another. So we can drop this dependency and just handle the differences between Python 2 and Python 3.