### PR TITLE
Add --timer-fail option to fail tests that exceed threshold

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,21 @@ Or to apply several filters at once::
 
     nosetests --with-timer --timer-filter warning,error
 
+How do I cause slow tests to fail?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can cause any tests that exceed a threshold to fail by specifying the
+``--timer-fail`` option:
+
+- If you specify ``--timer-fail warning``, slow tests which would be displayed
+  as a warning (i.e. that take more time than  ``--timer-ok``) will fail.
+- If you specify ``--timer-fail error``, slow tests which would be displayed as
+  an error (i.e. that take more time than ``--timer-warning``) will fail.
+
+For example, to fail any tests that take more than 5 seconds::
+
+    nosetests --with-timer --timer-warning 5.0 --timer-fail error
+
 
 How do I export the results ?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -130,6 +145,7 @@ Contribute
 Contributors
 ------------
 
+- `@acordiner <https://github.com/acordiner>`_
 - `@andresriancho <https://github.com/andresriancho>`_
 - `@cgoldberg <https://github.com/cgoldberg>`_
 - `@DmitrySandalov <https://github.com/DmitrySandalov>`_

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     description='A timer plugin for nosetests',
     long_description=open('README.rst').read(),
     author=', '.join([
+        'Alister Cordiner',
         'Andres Riancho',
         'Anton Egorov',
         'Arthur Kulik',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -22,9 +22,9 @@ class TestTimerPlugin(unittest.TestCase):
         parser = mock.MagicMock()
         self.plugin.options(parser)
         if not plugin.IS_NT:
-            self.assertEquals(parser.add_option.call_count, 7)
+            self.assertEquals(parser.add_option.call_count, 8)
         else:
-            self.assertEquals(parser.add_option.call_count, 6)
+            self.assertEquals(parser.add_option.call_count, 7)
 
     def test_configure(self):
         attributes = ('config', 'timer_top_n')
@@ -84,3 +84,19 @@ class TestTimerPlugin(unittest.TestCase):
         self.plugin.timer_no_color = True
         self.assertEqual(self.plugin._colored_time(1), "1.0000s")
         self.assertFalse(colored_mock.called)
+
+    @parameterized.expand([
+        ('warning', 0.5, False),
+        ('warning', 1.5, True),
+        ('error', 1.5, False),
+        ('error', 2.5, True),
+    ])
+    def test_timer_fail_option_warning_pass(self, timer_fail_level, time_taken,
+                                            fail_expected):
+        self.plugin.timer_fail = timer_fail_level
+        self.plugin.multiprocessing_enabled = False
+        with mock.patch.object(self.plugin, '_time_taken') as _time_taken:
+            _time_taken.return_value = time_taken
+            self.plugin.startTest(self.test_mock)
+            self.plugin.addSuccess(self.test_mock)
+            self.assertEqual(self.test_mock.fail.called, fail_expected)


### PR DESCRIPTION
This is my attempt at implementing the first part of #88. I haven't worked with nose plugins before (and the documentation is quite terse) so let me know if there's a better approach you had in mind!