### PR TITLE
BF/ENH: allow for a float as time specification as README.md suggests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,3 +164,4 @@ Contributors
 - `@satyrius <https://github.com/satyrius>`_
 - `@skudriashev <https://github.com/skudriashev>`_
 - `@whodafly <https://github.com/whodafly>`_
+- `@yarikoptic <https://github.com/yarikoptic>`_

--- a/nosetimer/plugin.py
+++ b/nosetimer/plugin.py
@@ -99,7 +99,7 @@ class TimerPlugin(Plugin):
     name = 'timer'
     score = 1
 
-    time_format = re.compile(r'^(?P<time>\d+)(?P<units>s|ms)?$')
+    time_format = re.compile(r'^(?P<time>\d+\.?\d*)(?P<units>s|ms)?$')
     _timed_tests = {}
 
     _COLOR_TO_FILTER = {
@@ -128,13 +128,13 @@ class TimerPlugin(Plugin):
         """
         try:
             # Default time unit is a second, we should convert it to milliseconds.
-            return int(value) * 1000
+            return float(value) * 1000
         except ValueError:
             # Try to parse if we are unlucky to cast value into int.
             m = self.time_format.match(value)
             if not m:
                 raise ValueError("Could not parse time represented by '{t}'".format(t=value))
-            time = int(m.group('time'))
+            time = float(m.group('time'))
             if m.group('units') != 'ms':
                 time *= 1000
             return time


### PR DESCRIPTION
First I thought that it might be better to just fix the README.md which
gives example

     nosetests --with-timer --timer-warning 5.0 --timer-fail error

but then decided that it would be better to fix the code to allow for such floating
number specification